### PR TITLE
fix: user profile 동물 이모지 연관 데이터에 type 지정

### DIFF
--- a/src/components/floating-action-button.tsx
+++ b/src/components/floating-action-button.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import color from 'styles/colors';
 
-const Button = styled.div`
+const Button = styled.a`
   position: fixed;
   width: 72px;
   height: 72px;

--- a/src/pages/trip/log-list.tsx
+++ b/src/pages/trip/log-list.tsx
@@ -2,18 +2,28 @@ import React from 'react';
 import styled from '@emotion/styled';
 import Graph from 'components/graph';
 import { GiveNTakeAmountProps } from 'components/graph';
+import { Animals } from 'components/profile';
 import Log from './log';
 
-const DUMMY = [
-  { id: 1, expender: '지형', profile: 'puppy', amount: 20000, desc: '휴게소', date: '2021-04-16' },
-  { id: 2, expender: '주예', profile: 'hamster', amount: 8000, desc: '아메리카노', date: '2021-04-16' },
-  { id: 3, expender: '유진', profile: 'rabbit', amount: 180000, desc: '게스트하우스', date: '2021-04-16' },
-  { id: 4, expender: '유진', profile: 'rabbit', amount: 180000, desc: '게스트하우스', date: '2021-04-15' },
-  { id: 5, expender: '유진', profile: 'rabbit', amount: 180000, desc: '게스트하우스', date: '2021-04-15' },
-  { id: 6, expender: '유진', profile: 'unicorn', amount: 180000, desc: '게스트하우스', date: '2021-04-15' },
-  { id: 7, expender: '유진', profile: 'rabbit', amount: 180000, desc: '게스트하우스', date: '2021-04-15' },
-  { id: 8, expender: '유진', profile: 'bear', amount: 180000, desc: '게스트하우스', date: '2021-04-15' },
-  { id: 9, expender: '유진', profile: 'rabbit', amount: 180000, desc: '게스트하우스', date: '2021-04-15' }
+interface Dummy {
+  id: number;
+  expender: string;
+  profile: keyof typeof Animals;
+  amount: number;
+  desc: string;
+  date: string;
+}
+
+const DUMMY: Dummy[] = [
+  { id: 1, expender: '지형', profile: 'Puppy', amount: 20000, desc: '휴게소', date: '2021-04-16' },
+  { id: 2, expender: '주예', profile: 'Hamster', amount: 8000, desc: '아메리카노', date: '2021-04-16' },
+  { id: 3, expender: '유진', profile: 'Rabbit', amount: 180000, desc: '게스트하우스', date: '2021-04-16' },
+  { id: 4, expender: '유진', profile: 'Rabbit', amount: 180000, desc: '게스트하우스', date: '2021-04-15' },
+  { id: 5, expender: '유진', profile: 'Rabbit', amount: 180000, desc: '게스트하우스', date: '2021-04-15' },
+  { id: 6, expender: '유진', profile: 'Unicorn', amount: 180000, desc: '게스트하우스', date: '2021-04-15' },
+  { id: 7, expender: '유진', profile: 'Rabbit', amount: 180000, desc: '게스트하우스', date: '2021-04-15' },
+  { id: 8, expender: '유진', profile: 'Bear', amount: 180000, desc: '게스트하우스', date: '2021-04-15' },
+  { id: 9, expender: '유진', profile: 'Rabbit', amount: 180000, desc: '게스트하우스', date: '2021-04-15' }
 ];
 
 const Wrap = styled.div`

--- a/src/pages/trip/log-list.tsx
+++ b/src/pages/trip/log-list.tsx
@@ -8,22 +8,22 @@ import Log from './log';
 interface Dummy {
   id: number;
   expender: string;
-  profile: keyof typeof Animals;
+  profile: Animals;
   amount: number;
   desc: string;
   date: string;
 }
 
 const DUMMY: Dummy[] = [
-  { id: 1, expender: '지형', profile: 'Puppy', amount: 20000, desc: '휴게소', date: '2021-04-16' },
-  { id: 2, expender: '주예', profile: 'Hamster', amount: 8000, desc: '아메리카노', date: '2021-04-16' },
-  { id: 3, expender: '유진', profile: 'Rabbit', amount: 180000, desc: '게스트하우스', date: '2021-04-16' },
-  { id: 4, expender: '유진', profile: 'Rabbit', amount: 180000, desc: '게스트하우스', date: '2021-04-15' },
-  { id: 5, expender: '유진', profile: 'Rabbit', amount: 180000, desc: '게스트하우스', date: '2021-04-15' },
-  { id: 6, expender: '유진', profile: 'Unicorn', amount: 180000, desc: '게스트하우스', date: '2021-04-15' },
-  { id: 7, expender: '유진', profile: 'Rabbit', amount: 180000, desc: '게스트하우스', date: '2021-04-15' },
-  { id: 8, expender: '유진', profile: 'Bear', amount: 180000, desc: '게스트하우스', date: '2021-04-15' },
-  { id: 9, expender: '유진', profile: 'Rabbit', amount: 180000, desc: '게스트하우스', date: '2021-04-15' }
+  { id: 1, expender: '지형', profile: Animals.Puppy, amount: 20000, desc: '휴게소', date: '2021-04-16' },
+  { id: 2, expender: '주예', profile: Animals.Hamster, amount: 8000, desc: '아메리카노', date: '2021-04-16' },
+  { id: 3, expender: '유진', profile: Animals.Rabbit, amount: 180000, desc: '게스트하우스', date: '2021-04-16' },
+  { id: 4, expender: '유진', profile: Animals.Rabbit, amount: 180000, desc: '게스트하우스', date: '2021-04-15' },
+  { id: 5, expender: '유진', profile: Animals.Rabbit, amount: 180000, desc: '게스트하우스', date: '2021-04-15' },
+  { id: 6, expender: '유진', profile: Animals.Unicorn, amount: 180000, desc: '게스트하우스', date: '2021-04-15' },
+  { id: 7, expender: '유진', profile: Animals.Rabbit, amount: 180000, desc: '게스트하우스', date: '2021-04-15' },
+  { id: 8, expender: '유진', profile: Animals.Bear, amount: 180000, desc: '게스트하우스', date: '2021-04-15' },
+  { id: 9, expender: '유진', profile: Animals.Rabbit, amount: 180000, desc: '게스트하우스', date: '2021-04-15' }
 ];
 
 const Wrap = styled.div`

--- a/src/pages/trip/log.tsx
+++ b/src/pages/trip/log.tsx
@@ -4,7 +4,8 @@ import styled from '@emotion/styled';
 import color from 'styles/colors';
 import Profile, { IconColors } from 'components/profile';
 import { Heading7, Heading5 as Amount, CaptionBold, Badge } from 'styles/typography';
-import { numberWithCommas, getProfileAnimalType } from 'utils';
+import { numberWithCommas } from 'utils';
+import { Animals } from 'components/profile';
 
 const Wrap = styled.div`
   width: 100%;
@@ -30,7 +31,7 @@ const flexBox = css`
 
 interface LogProps {
   expender: string;
-  profile: string;
+  profile: keyof typeof Animals;
   amount: number;
   desc: string;
 }
@@ -39,7 +40,7 @@ export default function Log({ expender, profile, amount, desc }: LogProps) {
   return (
     <Wrap>
       <div css={flexBox}>
-        <Profile iconColor={IconColors.Gray} type={getProfileAnimalType(profile)} />
+        <Profile iconColor={IconColors.Gray} type={Animals[profile]} />
         <Name>{expender}</Name>
       </div>
       <div

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,6 @@
 import { useLocation } from 'react-router';
 import { parse, format } from 'date-fns';
 import { ko } from 'date-fns/locale';
-import { Animals } from 'components/profile';
 
 export function useQuery() {
   return new URLSearchParams(useLocation().search);
@@ -17,38 +16,6 @@ export function makeDateFormat(date: Date) {
 
 export function numberWithCommas(number: number) {
   return number.toLocaleString();
-}
-
-export function getProfileAnimalType(type: string) {
-  switch (type) {
-    case 'puppy': {
-      return Animals.Puppy;
-    }
-    case 'bear': {
-      return Animals.Bear;
-    }
-    case 'unicorn': {
-      return Animals.Unicorn;
-    }
-    case 'hamster': {
-      return Animals.Hamster;
-    }
-    case 'fox': {
-      return Animals.Fox;
-    }
-    case 'panda': {
-      return Animals.Panda;
-    }
-    case 'tiger': {
-      return Animals.Tiger;
-    }
-    case 'rabbit': {
-      return Animals.Rabbit;
-    }
-    default: {
-      return Animals.Puppy;
-    }
-  }
 }
 
 export const calcRate = (num1: number, num2: number) => (num1 / num2) * 100;


### PR DESCRIPTION
## 내용
지난 pr에서 [동욱님 타입스크립트 관련 리뷰](https://github.com/Lubycon/ourney-front/pull/10#discussion_r633514741) 반영해봤습니다!
- 더미 데이터의 profile 필드에 Animals enum 의 키 타입 지정
- 불필요한 `getProfileAnimalType` 제거